### PR TITLE
Add test workflow for gh attestation verify command

### DIFF
--- a/.github/workflows/test-attestation.yml
+++ b/.github/workflows/test-attestation.yml
@@ -213,19 +213,6 @@ jobs:
             echo "Format flag not available for gh attestation verify"
           fi
 
-      - name: Cleanup
-        if: always()
-        run: |
-          TEMP_DIR="${{ steps.tempdir.outputs.dir }}"
-          if [ -d "$TEMP_DIR" ]; then
-            rm -rf "$TEMP_DIR"
-            echo "Temporary directory cleaned up: $TEMP_DIR"
-          fi
-          if [ -f "verify_output.txt" ]; then
-            rm verify_output.txt
-            echo "Output file cleaned up"
-          fi
-          
       - name: Verify attestation (with GH_FORCE_TTY)
         env:
           GH_TOKEN: ${{ github.token }}
@@ -253,3 +240,16 @@ jobs:
           
           # Clean up
           rm -f force_tty_output.txt
+
+      - name: Cleanup
+        if: always()
+        run: |
+          TEMP_DIR="${{ steps.tempdir.outputs.dir }}"
+          if [ -d "$TEMP_DIR" ]; then
+            rm -rf "$TEMP_DIR"
+            echo "Temporary directory cleaned up: $TEMP_DIR"
+          fi
+          if [ -f "verify_output.txt" ]; then
+            rm verify_output.txt
+            echo "Output file cleaned up"
+          fi

--- a/.github/workflows/test-attestation.yml
+++ b/.github/workflows/test-attestation.yml
@@ -225,3 +225,35 @@ jobs:
             rm verify_output.txt
             echo "Output file cleaned up"
           fi
+
+      - name: Install additional tools
+        run: |
+          echo "Installing additional tools for output capture testing"
+          sudo apt-get update
+          sudo apt-get install -y expect
+          
+      - name: Verify attestation (with alternative output capture methods)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TEMP_DIR="${{ steps.tempdir.outputs.dir }}"
+          IDENTITY_FILE="$TEMP_DIR/action-identity.json"
+          
+          echo "=== Method 1: Using stderr redirection to stdout and cat ==="
+          gh attestation verify "$IDENTITY_FILE" --repo $GITHUB_REPOSITORY 2>&1 | cat
+          
+          echo "=== Method 2: Capturing output in a variable ==="
+          OUTPUT=$(gh attestation verify "$IDENTITY_FILE" --repo $GITHUB_REPOSITORY 2>&1)
+          echo "$OUTPUT"
+          
+          echo "=== Method 3: Using process substitution ==="
+          cat <(gh attestation verify "$IDENTITY_FILE" --repo $GITHUB_REPOSITORY 2>&1)
+          
+          echo "=== Method 4: Using script command ==="
+          script -q /dev/null -c "gh attestation verify \"$IDENTITY_FILE\" --repo $GITHUB_REPOSITORY"
+          
+          echo "=== Method 5: Using stdbuf to disable buffering ==="
+          stdbuf -o0 -e0 gh attestation verify "$IDENTITY_FILE" --repo $GITHUB_REPOSITORY
+          
+          echo "=== Method 6: Using unbuffer from expect package ==="
+          unbuffer gh attestation verify "$IDENTITY_FILE" --repo $GITHUB_REPOSITORY

--- a/.github/workflows/test-attestation.yml
+++ b/.github/workflows/test-attestation.yml
@@ -1,0 +1,113 @@
+name: Test Attestation Verify
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  test-attestation:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup GitHub CLI
+        run: |
+          # GitHub CLIは最新のUbuntuランナーにはプリインストールされていますが、
+          # 念のため最新バージョンを確認
+          gh --version
+
+      - name: Get latest release
+        id: latest-release
+        run: |
+          # 最新のリリースタグを取得
+          LATEST_TAG=$(gh release list --repo $GITHUB_REPOSITORY --limit 1 | awk '{print $1}')
+          echo "Latest release tag: $LATEST_TAG"
+          echo "tag=$LATEST_TAG" >> $GITHUB_OUTPUT
+
+      - name: Create temporary directory
+        id: tempdir
+        run: |
+          # 一時ディレクトリを作成
+          TEMP_DIR=$(mktemp -d)
+          echo "dir=$TEMP_DIR" >> $GITHUB_OUTPUT
+          echo "Created temporary directory: $TEMP_DIR"
+
+      - name: Download attestation files
+        run: |
+          TAG="${{ steps.latest-release.outputs.tag }}"
+          TEMP_DIR="${{ steps.tempdir.outputs.dir }}"
+          
+          echo "Downloading files from release: $TAG"
+          
+          # action-identity.json と関連する attestation ファイルをダウンロード
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --pattern "action-identity.json" --dir "$TEMP_DIR"
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --pattern "action-identity.json.intoto.jsonl" --dir "$TEMP_DIR"
+          
+          echo "Downloaded files:"
+          ls -la "$TEMP_DIR"
+
+      - name: Verify attestation (standard output)
+        run: |
+          TEMP_DIR="${{ steps.tempdir.outputs.dir }}"
+          IDENTITY_FILE="$TEMP_DIR/action-identity.json"
+          
+          echo "=== Standard verification ==="
+          echo "Verifying build provenance attestation for action-identity.json"
+          gh attestation verify "$IDENTITY_FILE" --repo $GITHUB_REPOSITORY
+          echo "Standard verification exit code: $?"
+
+      - name: Verify attestation (with output redirection)
+        run: |
+          TEMP_DIR="${{ steps.tempdir.outputs.dir }}"
+          IDENTITY_FILE="$TEMP_DIR/action-identity.json"
+          
+          echo "=== Verification with output redirection ==="
+          gh attestation verify "$IDENTITY_FILE" --repo $GITHUB_REPOSITORY > verify_output.txt 2>&1
+          VERIFY_EXIT_CODE=$?
+          
+          echo "Verification output:"
+          cat verify_output.txt
+          echo "Verification with redirection exit code: $VERIFY_EXIT_CODE"
+
+      - name: Verify attestation (with verbose flag if available)
+        run: |
+          TEMP_DIR="${{ steps.tempdir.outputs.dir }}"
+          IDENTITY_FILE="$TEMP_DIR/action-identity.json"
+          
+          echo "=== Verification with verbose flag ==="
+          # --verboseフラグが利用可能かどうか確認
+          if gh attestation verify --help | grep -q -- "--verbose"; then
+            gh attestation verify "$IDENTITY_FILE" --repo $GITHUB_REPOSITORY --verbose
+          else
+            echo "Verbose flag not available, using standard command"
+            GITHUB_STEP_SUMMARY="Verbose flag not available for gh attestation verify"
+            gh attestation verify "$IDENTITY_FILE" --repo $GITHUB_REPOSITORY
+          fi
+          echo "Verification with verbose flag exit code: $?"
+
+      - name: Verify attestation (with debug environment variable)
+        run: |
+          TEMP_DIR="${{ steps.tempdir.outputs.dir }}"
+          IDENTITY_FILE="$TEMP_DIR/action-identity.json"
+          
+          echo "=== Verification with debug environment variable ==="
+          # GH_DEBUGを設定して詳細出力を有効化
+          export GH_DEBUG=1
+          gh attestation verify "$IDENTITY_FILE" --repo $GITHUB_REPOSITORY
+          echo "Verification with debug env exit code: $?"
+
+      - name: Cleanup
+        if: always()
+        run: |
+          TEMP_DIR="${{ steps.tempdir.outputs.dir }}"
+          if [ -d "$TEMP_DIR" ]; then
+            rm -rf "$TEMP_DIR"
+            echo "Temporary directory cleaned up: $TEMP_DIR"
+          fi
+          if [ -f "verify_output.txt" ]; then
+            rm verify_output.txt
+            echo "Output file cleaned up"
+          fi

--- a/.github/workflows/test-attestation.yml
+++ b/.github/workflows/test-attestation.yml
@@ -25,9 +25,20 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           # Get the latest release tag
-          LATEST_TAG=$(gh release list --repo $GITHUB_REPOSITORY --limit 1 | awk '{print $1}')
+          LATEST_RELEASE=$(gh release list --repo $GITHUB_REPOSITORY --limit 1 --json tagName,name -q '.[0]')
+          if [ -z "$LATEST_RELEASE" ]; then
+            echo "Error: No releases found in the repository"
+            exit 1
+          fi
+          
+          # Extract tag name using jq
+          LATEST_TAG=$(echo $LATEST_RELEASE | jq -r '.tagName')
           echo "Latest release tag: $LATEST_TAG"
           echo "tag=$LATEST_TAG" >> $GITHUB_OUTPUT
+          
+          # Also print release name for debugging
+          RELEASE_NAME=$(echo $LATEST_RELEASE | jq -r '.name')
+          echo "Release name: $RELEASE_NAME"
 
       - name: Create temporary directory
         id: tempdir
@@ -44,14 +55,61 @@ jobs:
           TAG="${{ steps.latest-release.outputs.tag }}"
           TEMP_DIR="${{ steps.tempdir.outputs.dir }}"
           
+          if [ -z "$TAG" ]; then
+            echo "Error: No tag name available"
+            exit 1
+          fi
+          
           echo "Downloading files from release: $TAG"
           
+          # List available assets for debugging
+          echo "Available release assets:"
+          gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json assets -q '.assets[].name'
+          
           # Download action-identity.json and related attestation files
-          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --pattern "action-identity.json" --dir "$TEMP_DIR"
-          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --pattern "action-identity.json.intoto.jsonl" --dir "$TEMP_DIR"
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --pattern "action-identity.json" --dir "$TEMP_DIR" || {
+            echo "Warning: Failed to download action-identity.json, checking for alternative locations"
+            # Try to find in subdirectories if direct download fails
+            gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --pattern "*/action-identity.json" --dir "$TEMP_DIR" || true
+          }
+          
+          gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --pattern "*.intoto.jsonl" --dir "$TEMP_DIR" || {
+            echo "Warning: Failed to download attestation files, checking for alternative locations"
+            # Try to find in subdirectories if direct download fails
+            gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --pattern "*/*.intoto.jsonl" --dir "$TEMP_DIR" || true
+          }
           
           echo "Downloaded files:"
           ls -la "$TEMP_DIR"
+          
+          # Check if we have the necessary files
+          if [ ! -f "$TEMP_DIR/action-identity.json" ] && [ ! -f "$TEMP_DIR"/*"/action-identity.json" ]; then
+            echo "Error: Could not find action-identity.json in downloaded files"
+            exit 1
+          fi
+          
+          # Find the actual path to action-identity.json
+          IDENTITY_FILE=$(find "$TEMP_DIR" -name "action-identity.json" | head -n 1)
+          echo "Found identity file at: $IDENTITY_FILE"
+          
+          # Copy to the expected location if it's in a subdirectory
+          if [ "$IDENTITY_FILE" != "$TEMP_DIR/action-identity.json" ]; then
+            cp "$IDENTITY_FILE" "$TEMP_DIR/action-identity.json"
+            echo "Copied identity file to: $TEMP_DIR/action-identity.json"
+          fi
+          
+          # Find attestation file
+          ATTESTATION_FILE=$(find "$TEMP_DIR" -name "*.intoto.jsonl" | head -n 1)
+          if [ -n "$ATTESTATION_FILE" ]; then
+            echo "Found attestation file at: $ATTESTATION_FILE"
+            # Copy to the expected location if needed
+            if [ "$ATTESTATION_FILE" != "$TEMP_DIR/action-identity.json.intoto.jsonl" ]; then
+              cp "$ATTESTATION_FILE" "$TEMP_DIR/action-identity.json.intoto.jsonl"
+              echo "Copied attestation file to: $TEMP_DIR/action-identity.json.intoto.jsonl"
+            fi
+          else
+            echo "Warning: No attestation file found"
+          fi
 
       - name: Verify attestation (standard output)
         env:

--- a/.github/workflows/test-attestation.yml
+++ b/.github/workflows/test-attestation.yml
@@ -190,6 +190,29 @@ jobs:
             echo "Expected failure occurred with exit code: $?"
           }
 
+      - name: Verify attestation (with JSON format)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TEMP_DIR="${{ steps.tempdir.outputs.dir }}"
+          IDENTITY_FILE="$TEMP_DIR/action-identity.json"
+          
+          echo "=== Verification with JSON format ==="
+          # Check if --format flag is available
+          if gh attestation verify --help | grep -q -- "--format"; then
+            echo "Using --format json option"
+            gh attestation verify "$IDENTITY_FILE" --repo $GITHUB_REPOSITORY --format json | jq .
+            echo "JSON format verification exit code: $?"
+            
+            # Also try with a failing verification
+            echo "=== Failing verification with JSON format ==="
+            gh attestation verify "$IDENTITY_FILE" --repo "github/docs" --format json 2>&1 || {
+              echo "Expected failure occurred with exit code: $?"
+            }
+          else
+            echo "Format flag not available for gh attestation verify"
+          fi
+
       - name: Cleanup
         if: always()
         run: |

--- a/.github/workflows/test-attestation.yml
+++ b/.github/workflows/test-attestation.yml
@@ -15,14 +15,16 @@ jobs:
 
       - name: Setup GitHub CLI
         run: |
-          # GitHub CLIは最新のUbuntuランナーにはプリインストールされていますが、
-          # 念のため最新バージョンを確認
+          # GitHub CLI is pre-installed on the latest Ubuntu runners,
+          # but check the version just to be sure
           gh --version
 
       - name: Get latest release
         id: latest-release
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          # 最新のリリースタグを取得
+          # Get the latest release tag
           LATEST_TAG=$(gh release list --repo $GITHUB_REPOSITORY --limit 1 | awk '{print $1}')
           echo "Latest release tag: $LATEST_TAG"
           echo "tag=$LATEST_TAG" >> $GITHUB_OUTPUT
@@ -30,19 +32,21 @@ jobs:
       - name: Create temporary directory
         id: tempdir
         run: |
-          # 一時ディレクトリを作成
+          # Create a temporary directory
           TEMP_DIR=$(mktemp -d)
           echo "dir=$TEMP_DIR" >> $GITHUB_OUTPUT
           echo "Created temporary directory: $TEMP_DIR"
 
       - name: Download attestation files
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           TAG="${{ steps.latest-release.outputs.tag }}"
           TEMP_DIR="${{ steps.tempdir.outputs.dir }}"
           
           echo "Downloading files from release: $TAG"
           
-          # action-identity.json と関連する attestation ファイルをダウンロード
+          # Download action-identity.json and related attestation files
           gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --pattern "action-identity.json" --dir "$TEMP_DIR"
           gh release download "$TAG" --repo "$GITHUB_REPOSITORY" --pattern "action-identity.json.intoto.jsonl" --dir "$TEMP_DIR"
           
@@ -50,6 +54,8 @@ jobs:
           ls -la "$TEMP_DIR"
 
       - name: Verify attestation (standard output)
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           TEMP_DIR="${{ steps.tempdir.outputs.dir }}"
           IDENTITY_FILE="$TEMP_DIR/action-identity.json"
@@ -60,6 +66,8 @@ jobs:
           echo "Standard verification exit code: $?"
 
       - name: Verify attestation (with output redirection)
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           TEMP_DIR="${{ steps.tempdir.outputs.dir }}"
           IDENTITY_FILE="$TEMP_DIR/action-identity.json"
@@ -73,12 +81,14 @@ jobs:
           echo "Verification with redirection exit code: $VERIFY_EXIT_CODE"
 
       - name: Verify attestation (with verbose flag if available)
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           TEMP_DIR="${{ steps.tempdir.outputs.dir }}"
           IDENTITY_FILE="$TEMP_DIR/action-identity.json"
           
           echo "=== Verification with verbose flag ==="
-          # --verboseフラグが利用可能かどうか確認
+          # Check if --verbose flag is available
           if gh attestation verify --help | grep -q -- "--verbose"; then
             gh attestation verify "$IDENTITY_FILE" --repo $GITHUB_REPOSITORY --verbose
           else
@@ -89,13 +99,15 @@ jobs:
           echo "Verification with verbose flag exit code: $?"
 
       - name: Verify attestation (with debug environment variable)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_DEBUG: 1
         run: |
           TEMP_DIR="${{ steps.tempdir.outputs.dir }}"
           IDENTITY_FILE="$TEMP_DIR/action-identity.json"
           
           echo "=== Verification with debug environment variable ==="
-          # GH_DEBUGを設定して詳細出力を有効化
-          export GH_DEBUG=1
+          # Set GH_DEBUG to enable detailed output
           gh attestation verify "$IDENTITY_FILE" --repo $GITHUB_REPOSITORY
           echo "Verification with debug env exit code: $?"
 

--- a/.github/workflows/test-attestation.yml
+++ b/.github/workflows/test-attestation.yml
@@ -225,35 +225,31 @@ jobs:
             rm verify_output.txt
             echo "Output file cleaned up"
           fi
-
-      - name: Install additional tools
-        run: |
-          echo "Installing additional tools for output capture testing"
-          sudo apt-get update
-          sudo apt-get install -y expect
           
-      - name: Verify attestation (with alternative output capture methods)
+      - name: Verify attestation (with GH_FORCE_TTY)
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_FORCE_TTY: 1
         run: |
           TEMP_DIR="${{ steps.tempdir.outputs.dir }}"
           IDENTITY_FILE="$TEMP_DIR/action-identity.json"
           
-          echo "=== Method 1: Using stderr redirection to stdout and cat ==="
-          gh attestation verify "$IDENTITY_FILE" --repo $GITHUB_REPOSITORY 2>&1 | cat
+          echo "=== Using GH_FORCE_TTY environment variable ==="
+          echo "Setting GH_FORCE_TTY=1 to force TTY mode"
+          gh attestation verify "$IDENTITY_FILE" --repo $GITHUB_REPOSITORY
+          echo "GH_FORCE_TTY verification exit code: $?"
           
-          echo "=== Method 2: Capturing output in a variable ==="
-          OUTPUT=$(gh attestation verify "$IDENTITY_FILE" --repo $GITHUB_REPOSITORY 2>&1)
-          echo "$OUTPUT"
+          # Also try with output redirection
+          echo "=== Using GH_FORCE_TTY with output redirection ==="
+          gh attestation verify "$IDENTITY_FILE" --repo $GITHUB_REPOSITORY > force_tty_output.txt 2>&1
+          echo "Output with GH_FORCE_TTY:"
+          cat force_tty_output.txt
           
-          echo "=== Method 3: Using process substitution ==="
-          cat <(gh attestation verify "$IDENTITY_FILE" --repo $GITHUB_REPOSITORY 2>&1)
+          # Try with a failing verification
+          echo "=== Failing verification with GH_FORCE_TTY ==="
+          gh attestation verify "$IDENTITY_FILE" --repo "github/docs" 2>&1 || {
+            echo "Expected failure occurred with exit code: $?"
+          }
           
-          echo "=== Method 4: Using script command ==="
-          script -q /dev/null -c "gh attestation verify \"$IDENTITY_FILE\" --repo $GITHUB_REPOSITORY"
-          
-          echo "=== Method 5: Using stdbuf to disable buffering ==="
-          stdbuf -o0 -e0 gh attestation verify "$IDENTITY_FILE" --repo $GITHUB_REPOSITORY
-          
-          echo "=== Method 6: Using unbuffer from expect package ==="
-          unbuffer gh attestation verify "$IDENTITY_FILE" --repo $GITHUB_REPOSITORY
+          # Clean up
+          rm -f force_tty_output.txt

--- a/.github/workflows/test-attestation.yml
+++ b/.github/workflows/test-attestation.yml
@@ -168,6 +168,27 @@ jobs:
           # Set GH_DEBUG to enable detailed output
           gh attestation verify "$IDENTITY_FILE" --repo $GITHUB_REPOSITORY
           echo "Verification with debug env exit code: $?"
+      
+      - name: Verify attestation (intentionally failing)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TEMP_DIR="${{ steps.tempdir.outputs.dir }}"
+          IDENTITY_FILE="$TEMP_DIR/action-identity.json"
+          
+          echo "=== Intentionally failing verification ==="
+          echo "Using wrong repository to force failure and see error output"
+          
+          # Use a different repository to force verification failure
+          gh attestation verify "$IDENTITY_FILE" --repo "github/docs" || {
+            echo "Expected failure occurred with exit code: $?"
+          }
+          
+          # Try with stderr redirection to see if errors are shown
+          echo "=== Failing verification with stderr capture ==="
+          gh attestation verify "$IDENTITY_FILE" --repo "github/docs" 2>&1 || {
+            echo "Expected failure occurred with exit code: $?"
+          }
 
       - name: Cleanup
         if: always()


### PR DESCRIPTION
This PR adds a test workflow to investigate the issue where the output of the `gh attestation verify` command is not displayed in GitHub Actions workflow logs.

The workflow performs the following tests:
1. Automatically detects and uses the latest release
2. Executes the `gh attestation verify` command in four different ways:
   - Standard execution (normal output)
   - Output redirection (capturing both stdout/stderr)
   - Verbose flag (if available)
   - Using the GH_DEBUG environment variable

This will help identify which method is most effective for displaying the command output.