### PR TITLE
Fix gh attestation verify output not showing in workflow logs

### DIFF
--- a/.github/workflows/slsa-action-release.yml
+++ b/.github/workflows/slsa-action-release.yml
@@ -330,11 +330,15 @@ jobs:
       - name: Verify build provenance attestation (gh attestation verify)
         env:
           GITHUB_TOKEN: ${{ secrets.github-token }}
+          GH_FORCE_TTY: 1
         run: |
           TEMP_DIR="${{ steps.tempdir.outputs.dir }}"
           IDENTITY_FILE="$TEMP_DIR/action-identity.json"
           echo "Verifying build provenance attestation for action-identity.json"
+
           gh attestation verify "$IDENTITY_FILE" --repo $GITHUB_REPOSITORY
+
+          echo "✅ Build provenance attestation verification successful!"
 
       - name: Cleanup
         if: always()


### PR DESCRIPTION
This PR adds the GH_FORCE_TTY environment variable to the gh attestation verify step in the SLSA action release workflow.

## Problem
The output of the gh attestation verify command was not showing in GitHub Actions workflow logs.

## Solution
Setting the GH_FORCE_TTY=1 environment variable forces GitHub CLI to operate in TTY mode, which ensures that the output is properly displayed in the workflow logs.

This fix was identified through testing in PR #29, where we confirmed that setting this environment variable resolves the issue.