### PR TITLE
Add option to create releases in draft mode

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,5 @@ jobs:
       actions: read      # Required for SLSA generator
       attestations: write # Required for build provenance attestation
     uses: ./.github/workflows/slsa-action-release.yml
-    with:
-      branch: ${{ github.event.repository.default_branch }}
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/slsa-action-release.yml
+++ b/.github/workflows/slsa-action-release.yml
@@ -16,6 +16,11 @@ on:
         required: false
         type: boolean
         default: true
+      draft:
+        description: 'Whether to keep the release as a draft'
+        required: false
+        type: boolean
+        default: false
     secrets:
       github-token:
         description: 'GitHub token with appropriate permissions'
@@ -212,7 +217,7 @@ jobs:
           RELEASE_URL=$(gh release edit "$TAG_NAME" \
             --title "Release $TAG_NAME" \
             --notes "$(gh release view "$TAG_NAME" --json body -q .body || echo "")" \
-            --draft=false)
+            --draft=${{ inputs.draft }})
 
           echo "release_url=$RELEASE_URL" >> $GITHUB_OUTPUT
           echo "Release URL: $RELEASE_URL"


### PR DESCRIPTION
This PR adds a new 'draft' option to the SLSA-compliant release workflow, allowing releases to be created in draft mode.