### PR TITLE
Fix release creation workflow

### DIFF
--- a/.github/workflows/trusted-release-workflow.yml
+++ b/.github/workflows/trusted-release-workflow.yml
@@ -176,7 +176,7 @@ jobs:
     permissions:
       contents: write # Required for release creation
     outputs:
-      release_url: ${{ steps.update_release.outputs.release_url }}
+      release_url: ${{ steps.create_release.outputs.release_url }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -190,17 +190,14 @@ jobs:
         with:
           name: release-identity-intoto
 
-      # Update release
-      - name: Update GitHub Release
-        id: update_release
+      # Create GitHub Release
+      - name: Create GitHub Release
+        id: create_release
         env:
           GITHUB_TOKEN: ${{ secrets.github-token }}
         run: |
           TAG_NAME="${{ needs.prepare-slsa.outputs.tag_name }}"
           REPO="${GITHUB_REPOSITORY}"
-
-          # Upload artifacts to the release
-          gh release upload "$TAG_NAME" release-identity.intoto.jsonl --clobber
 
           # Generate release notes using GitHub API
           echo "Generating release notes using GitHub API..."
@@ -216,11 +213,12 @@ jobs:
             -f previous_tag_name="$CURRENT_VERSION" \
             --jq '.body')
 
-          # Update release with generated notes
-          RELEASE_URL=$(gh release edit "$TAG_NAME" \
+          # Create release with generated notes
+          RELEASE_URL=$(gh release create "$TAG_NAME" \
             --title "Release $TAG_NAME" \
             --draft=${{ inputs.draft }} \
-            --notes "$RELEASE_NOTES")
+            --notes "$RELEASE_NOTES" \
+            release-identity.intoto.jsonl)
 
           echo "release_url=$RELEASE_URL" >> $GITHUB_OUTPUT
           echo "Release URL: $RELEASE_URL"


### PR DESCRIPTION
## Summary
Fix the release creation process after removing slsa-github-generator dependency.

## Problem
The previous workflow relied on the `generate-provenance` step to create draft releases. After removing slsa-github-generator, the `Update GitHub Release` step fails because no release exists to update.

## Changes
- Replace `Update GitHub Release` with `Create GitHub Release`
- Move artifact upload to the release creation command
- Update step ID and output references

## Test plan
- [ ] Verify workflow syntax with actionlint
- [ ] Test release creation with bump:patch label
- [ ] Confirm release artifacts are properly attached

🤖 Generated with [Claude Code](https://claude.ai/code)