### PR TITLE
Fix workflow parameter from branch to ref

### DIFF
--- a/.github/workflows/trusted-release-workflow.yml
+++ b/.github/workflows/trusted-release-workflow.yml
@@ -6,10 +6,10 @@ name: Trusted Release Workflow
 on:
   workflow_call:
     inputs:
-      branch:
-        description: 'The working branch'
+      ref:
+        description: 'The Git reference (commit SHA, tag, or branch) to use'
         required: false
-        default: ${{ github.event.repository.default_branch }}
+        default: ${{ github.sha }}
         type: string
       rekor-log-public:
         description: 'Allow repository name to be logged in public Rekor transparency log'
@@ -51,7 +51,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.branch }}
+          ref: ${{ inputs.ref }}
 
       # Set up signed tag configuration
       - uses: chainguard-dev/actions/setup-gitsign@1054a7f14edea88ef30dc2732c0a5e8d05db4ecc


### PR DESCRIPTION
## Summary
- Fixed workflow configuration issue by changing the input parameter from `branch` to `ref`
- This change aligns with the same fix applied in [trusted-go-releaser PR #11](https://github.com/actionutils/trusted-go-releaser/pull/11)

## Changes
- Updated workflow input to accept commit SHA, tag, or branch references
- Changed the default value to use `github.sha` instead of the default branch
- Updated checkout steps to use the new `ref` input

This prevents unintended behavior when additional commits are pushed after workflow trigger.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow input to use a more flexible reference parameter, allowing commits, tags, or branches, with improved description and default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->