### PR TITLE
Update trusted-tag-verifier usage to unified format

### DIFF
--- a/.github/workflows/trusted-release-workflow.yml
+++ b/.github/workflows/trusted-release-workflow.yml
@@ -352,8 +352,7 @@ jobs:
         id: verify-tag
         uses: actionutils/trusted-tag-verifier@v0
         with:
-          repository: '${{ github.repository }}'
-          tag: '${{ needs.prepare-slsa.outputs.tag_name }}'
+          verify: '${{ github.repository }}@${{ needs.prepare-slsa.outputs.tag_name }}'
           fail-on-verification-error: 'true'
           certificate-oidc-issuer: 'https://token.actions.githubusercontent.com'
           certificate-identity-regexp: '^https://github.com/actionutils/trusted-tag-releaser'
@@ -363,8 +362,7 @@ jobs:
         if: needs.prepare-slsa.outputs.major_tag != ''
         uses: actionutils/trusted-tag-verifier@v0
         with:
-          repository: '${{ github.repository }}'
-          tag: '${{ needs.prepare-slsa.outputs.major_tag }}'
+          verify: '${{ github.repository }}@${{ needs.prepare-slsa.outputs.major_tag }}'
           fail-on-verification-error: 'true'
           certificate-oidc-issuer: 'https://token.actions.githubusercontent.com'
           certificate-identity-regexp: '^https://github.com/actionutils/trusted-tag-releaser'
@@ -374,8 +372,7 @@ jobs:
         if: needs.prepare-slsa.outputs.minor_tag != ''
         uses: actionutils/trusted-tag-verifier@v0
         with:
-          repository: '${{ github.repository }}'
-          tag: '${{ needs.prepare-slsa.outputs.minor_tag }}'
+          verify: '${{ github.repository }}@${{ needs.prepare-slsa.outputs.minor_tag }}'
           fail-on-verification-error: 'true'
           certificate-oidc-issuer: 'https://token.actions.githubusercontent.com'
           certificate-identity-regexp: '^https://github.com/actionutils/trusted-tag-releaser'


### PR DESCRIPTION
## Summary
- Update workflow to use the new unified verify parameter format

## Changes
- Replace `repository` and `tag` inputs with `verify` input using format `<owner>/<repo>@<version>`

## Related
- Depends on actionutils/trusted-tag-verifier#11

🤖 Generated with [Claude Code](https://claude.ai/code)