### PR TITLE
feat: add environment protection for semver tags updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,7 @@ jobs:
     uses: ./.github/workflows/trusted-release-workflow.yml
     with:
       environment: release
+      semver-tags-environment: release-semver-tags
       release-notes: ${{ fromJSON(needs.release-pr.outputs.release_pr).release_notes }}
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/trusted-release-workflow.yml
+++ b/.github/workflows/trusted-release-workflow.yml
@@ -29,6 +29,10 @@ on:
         description: 'Custom release notes content (overrides auto-generated notes)'
         required: false
         type: string
+      semver-tags-environment:
+        description: 'Environment for protecting the major/minor semver tags update (allows using wait timers to delay v1/v2 tag updates)'
+        required: false
+        type: string
     secrets:
       github-token:
         description: 'GitHub token with appropriate permissions'
@@ -480,6 +484,10 @@ jobs:
     needs: [release, version]
     if: needs.version.outputs.tag_name != ''
     runs-on: ubuntu-latest
+    environment: ${{ inputs.semver-tags-environment }}
+    concurrency:
+      group: "semver-tags-update"
+      cancel-in-progress: true
     permissions:
       id-token: write # Enable OIDC for gitsign
       contents: write # Required to update tags


### PR DESCRIPTION
## Summary
- Add configurable environment protection for major/minor semver tag updates (v1, v2, etc.)
- Enable wait timers and approval workflows specifically for semver tags
- Maintain separate protection rules from the main release process

## Changes
- Added new `semver-tags-environment` input to `trusted-release-workflow.yml`
- Configured `update-semver-tags` job with environment and concurrency settings
- Updated `release.yml` to pass `release-semver-tags` environment

## Benefits
This change allows repository maintainers to:
- Set up wait timers specifically for major/minor tag updates
- Test the specific version release before updating floating tags
- Have different protection rules for initial release vs semver tag updates
- Cancel in-progress semver tag updates if needed

## Test plan
- [ ] Verify workflow syntax is valid
- [ ] Test with environment protection rules configured
- [ ] Confirm semver tags update respects the environment settings
- [ ] Verify concurrency cancellation works as expected

🤖 Generated with [Claude Code](https://claude.ai/code)