### PR TITLE
refactor: deprecate github-token secret input in trusted-release-workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,5 +49,3 @@ jobs:
       environment: release
       semver-tags-environment: release-semver-tags
       release-notes: ${{ fromJSON(needs.release-pr.outputs.release_pr).release_notes }}
-    secrets:
-      github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/trusted-release-workflow.yml
+++ b/.github/workflows/trusted-release-workflow.yml
@@ -35,8 +35,8 @@ on:
         type: string
     secrets:
       github-token:
-        description: 'GitHub token with appropriate permissions'
-        required: true
+        description: 'DEPRECATED: This input is deprecated and will be removed in future versions. The workflow now uses the default GITHUB_TOKEN automatically. You can safely remove this input from your workflow calls.'
+        required: false
     outputs:
       tag_name:
         description: 'The tag name created or used for this release'
@@ -111,7 +111,7 @@ jobs:
         id: create-temp-branch
         if: steps.bumpr-dry-run.outputs.skip != 'true'
         env:
-          GITHUB_TOKEN: ${{ secrets.github-token || github.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NEXT_VERSION: ${{ steps.bumpr-dry-run.outputs.next_version }}
           COMMIT_SHA: ${{ github.sha }}
         run: |
@@ -142,7 +142,7 @@ jobs:
       # Add release information to job summary
       - name: Add release information to job summary
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CUSTOM_RELEASE_NOTES: ${{ inputs.release-notes }}
           SKIP: ${{ steps.bumpr-dry-run.outputs.skip }}
           NEXT_VERSION: ${{ steps.bumpr-dry-run.outputs.next_version }}
@@ -339,7 +339,7 @@ jobs:
       - name: Compute tag SHA and subjects
         id: compute-subjects
         env:
-          GITHUB_TOKEN: ${{ secrets.github-token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_NAME: ${{ needs.version.outputs.tag_name }}
         run: |
 
@@ -396,7 +396,7 @@ jobs:
       - name: Update GitHub Release
         id: create_release
         env:
-          GITHUB_TOKEN: ${{ secrets.github-token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_NAME: ${{ needs.version.outputs.tag_name }}
           CUSTOM_RELEASE_NOTES: ${{ inputs.release-notes }}
           CURRENT_VERSION: ${{ needs.version.outputs.current_version }}
@@ -551,7 +551,7 @@ jobs:
       # See: https://github.com/orgs/community/discussions/151442
       - name: Delete temporary branch
         env:
-          GITHUB_TOKEN: ${{ secrets.github-token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TEMP_BRANCH: ${{ needs.release-check.outputs.temp_branch }}
         run: |
           # Get the exact branch name that was created
@@ -592,7 +592,7 @@ jobs:
 
       - name: Verify SLSA provenance with slsa-verifier
         env:
-          GITHUB_TOKEN: ${{ secrets.github-token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ needs.version.outputs.tag_name }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary
- Deprecated the `github-token` secret input in favor of using the default `secrets.GITHUB_TOKEN`
- Updated all token references throughout the workflow to use `secrets.GITHUB_TOKEN` directly
- Maintained backward compatibility for existing workflows

## Details

This PR deprecates the explicit `github-token` secret input in the `trusted-release-workflow.yml` reusable workflow. The workflow now uses GitHub's default `secrets.GITHUB_TOKEN` directly, which is the recommended best practice.

### Changes:
1. **Secret input deprecation**: Marked `github-token` as optional (`required: false`) with a deprecation notice
2. **Token usage update**: All `GITHUB_TOKEN` environment variable assignments now use `secrets.GITHUB_TOKEN`
3. **Backward compatibility**: Existing workflows passing `github-token` will continue to work

### Why this change?
- **Simplification**: Users no longer need to explicitly pass the GitHub token
- **Best practices**: Using the default `GITHUB_TOKEN` is the recommended approach
- **Security**: Reduces the chance of accidentally exposing tokens

### Migration guide for users:
Users can safely remove the `github-token` secret from their workflow calls:

```yaml
# Before
jobs:
  release:
    uses: actionutils/trusted-tag-releaser/.github/workflows/trusted-release-workflow.yml@v2
    secrets:
      github-token: ${{ secrets.GITHUB_TOKEN }}  # ← Remove this line

# After  
jobs:
  release:
    uses: actionutils/trusted-tag-releaser/.github/workflows/trusted-release-workflow.yml@v2
    # No secrets needed - uses default GITHUB_TOKEN automatically
```

## Test plan
- [ ] Existing workflows with `github-token` secret continue to work
- [ ] Workflows without `github-token` secret use the default token successfully
- [ ] All release operations function correctly with the default token

🤖 Generated with [Claude Code](https://claude.ai/code)